### PR TITLE
fix: use Directory.asFile property

### DIFF
--- a/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/ScaffoldTask.groovy
+++ b/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/ScaffoldTask.groovy
@@ -89,7 +89,7 @@ abstract class ScaffoldTask extends DefaultTask {
                 // The source root is the parent directory of the anchor file.
                 def sourceRoot = anchorPathInJar.parent
 
-                ResourceCopier.copy(sourceRoot, destinationDir.get().asFile().toPath())
+                ResourceCopier.copy(sourceRoot, destinationDir.get().asFile.toPath())
 
                 copyAndModifyConfig(sourceRoot)
             }


### PR DESCRIPTION
## Summary
- fix Directory usage in ScaffoldTask by using the `asFile` property for `destinationDir`

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a0bdb737388330bba739cdf4433583