### PR TITLE
feat: scaffold in current directory by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,29 +60,30 @@ plugins {
 
 ### 2. Scaffold a New Site Project
 
-To scaffold a new project structure, run the following command in your terminal:
+To scaffold a new project structure in the current directory, run:
 
 ```bash
 ./gradlew grim-init
 ```
 
-This will generate a basic site structure under your project directory:
+This will generate a basic site structure alongside your existing files:
 
 ```
 <project-root>/
-├── site/
-│   ├── config.grim            # Groovy-based site configuration
-│   ├── pages/                 # Markdown or HTML page files
-│   ├── layouts/               # Handlebars layouts
-│   ├── partials/              # Optional Handlebars partials
-│   └── data/                  # Optional data in JSON/YAML/Groovy
+├── config.grim            # Groovy-based site configuration
+├── pages/                 # Markdown or HTML page files
+├── layouts/               # Handlebars layouts
+├── partials/              # Optional Handlebars partials
+└── data/                  # Optional data in JSON/YAML/Groovy
 ```
 
-You can also specify a custom root directory:
+Use `--dest` to scaffold into a specific subdirectory:
 
 ```bash
 ./gradlew grim-init --dest=my-docs
 ```
+
+The task will abort if any of the files it intends to create already exist, helping prevent accidental overwrites.
 
 ### 3. Build Your Site
 

--- a/plugin/src/main/groovy/biz/digitalindustry/grimoire/util/ResourceCopier.groovy
+++ b/plugin/src/main/groovy/biz/digitalindustry/grimoire/util/ResourceCopier.groovy
@@ -4,7 +4,6 @@ import org.gradle.api.GradleException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.io.IOException
-import java.nio.file.StandardCopyOption
 
 /**
  * A utility for recursively copying directory structures, designed to work
@@ -26,12 +25,13 @@ class ResourceCopier {
                 if (Files.isDirectory(sourcePath)) {
                     Files.createDirectories(targetPath)
                 } else {
-                    // Ensure the parent directory exists before copying the file.
-                    // This is crucial for a clean, atomic copy operation.
+                    if (Files.exists(targetPath)) {
+                        throw new GradleException("Cannot overwrite existing file: ${targetPath}")
+                    }
                     if (targetPath.parent != null) {
                         Files.createDirectories(targetPath.parent)
                     }
-                    Files.copy(sourcePath, targetPath, StandardCopyOption.REPLACE_EXISTING)
+                    Files.copy(sourcePath, targetPath)
                 }
             }
         } catch (IOException e) {

--- a/plugin/src/test/groovy/biz/digitalindustry/grimoire/SiteGenPluginSpec.groovy
+++ b/plugin/src/test/groovy/biz/digitalindustry/grimoire/SiteGenPluginSpec.groovy
@@ -18,7 +18,10 @@ class SiteGenPluginSpec extends Specification {
         Path projectRoot = Paths.get(".").toAbsolutePath().normalize()
         //testDir = project.getProjectDir().toPath().resolve("grimoire-test-site")
         testDir = projectRoot.resolve("grimoire-test-site")
-        testDir.toFile().delete()
+        def testDirFile = testDir.toFile()
+        if (testDirFile.exists()) {
+            assert testDirFile.deleteDir()
+        }
         Files.createDirectories(testDir)
         //testDir = Files.createDirectory(project.getProjectDir().toPath(),"grimoire-test-site")
         ResourceCopier.copy(fixture, testDir)


### PR DESCRIPTION
## Summary
- default `grim-init` to current directory with optional `--dest`
- abort scaffolding if it would overwrite existing files
- document new defaults and update tests

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c566fa508330894c33c470acc40a