### PR TITLE
Add grim-init force behavior tests and jar path handling

### DIFF
--- a/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/ScaffoldTask.groovy
+++ b/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/ScaffoldTask.groovy
@@ -45,10 +45,19 @@ abstract class ScaffoldTask extends DefaultTask {
     @Option(option = "type", description = "The type of site to scaffold (e.g., 'basic').")
     abstract Property<String> getType()
 
+    /**
+     * When {@code true}, the task will scaffold into a destination directory even if it already
+     * contains files. Existing files are left untouched, but conflicts will still cause failures.
+     */
+    @Input
+    @Option(option = "force", description = "Force initialization even if the destination directory is not empty.")
+    abstract Property<Boolean> getForce()
+
     ScaffoldTask() {
         // Set default values for the properties
         type.convention("basic") // Default to the 'basic' scaffold
         destinationDir.convention(project.layout.projectDirectory)
+        force.convention(false)
     }
 
     @TaskAction
@@ -58,6 +67,14 @@ abstract class ScaffoldTask extends DefaultTask {
         def destConfigFile = new File(projectRootDir.get().asFile, "config.grim")
         if (destConfigFile.exists()) {
             throw new GradleException("config.grim already exists at destination")
+        }
+
+        if (destDir.exists()) {
+            def allowed = ["build.gradle", "settings.gradle", ".gradle", "gradlew", "gradlew.bat"]
+            def existing = destDir.listFiles()?.findAll { !allowed.contains(it.name) }
+            if (existing && !force.get()) {
+                throw new GradleException("Destination directory '${destDir.absolutePath}' is not empty. Use --force to scaffold anyway.")
+            }
         }
 
         destDir.mkdirs()


### PR DESCRIPTION
## Summary
- Support `--force` option in `ScaffoldTask` to scaffold into non-empty directories
- Cover grim-init behavior for non-empty directories with and without `--force`
- Verify grim-init runs correctly when using plugin JAR from build output

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ccfae0ec8330b45f56cdf84a76f8