### PR TITLE
Allow grim-init to scaffold into non-empty directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Use `--dest` to scaffold into a specific subdirectory:
 ./gradlew grim-init --dest=my-docs
 ```
 
-The task will abort if any of the files it intends to create already exist, helping prevent accidental overwrites.
+Existing files are left untouched; the task skips files that already exist to avoid overwriting.
 
 ### 3. Build Your Site
 

--- a/plugin/src/main/groovy/biz/digitalindustry/grimoire/util/ResourceCopier.groovy
+++ b/plugin/src/main/groovy/biz/digitalindustry/grimoire/util/ResourceCopier.groovy
@@ -25,13 +25,12 @@ class ResourceCopier {
                 if (Files.isDirectory(sourcePath)) {
                     Files.createDirectories(targetPath)
                 } else {
-                    if (Files.exists(targetPath)) {
-                        throw new GradleException("Cannot overwrite existing file: ${targetPath}")
+                    if (!Files.exists(targetPath)) {
+                        if (targetPath.parent != null) {
+                            Files.createDirectories(targetPath.parent)
+                        }
+                        Files.copy(sourcePath, targetPath)
                     }
-                    if (targetPath.parent != null) {
-                        Files.createDirectories(targetPath.parent)
-                    }
-                    Files.copy(sourcePath, targetPath)
                 }
             }
         } catch (IOException e) {


### PR DESCRIPTION
## Summary
- remove `--force` option and allow `grim-init` to scaffold without failing for non-empty directories
- skip copying `config.grim` when it already exists
- copy scaffold files without overwriting existing content

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a0fcbd50708330a93fcf0cb5b3d90a