### PR TITLE
Include original exception message in SiteGenTask

### DIFF
--- a/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/SiteGenTask.groovy
+++ b/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/SiteGenTask.groovy
@@ -169,7 +169,7 @@ abstract class SiteGenTask extends DefaultTask {
                     logger.info("Generated page: {} (layout: {})", outFile.name, layoutName)
                 }
             } catch (Exception e) {
-                throw new GradleException("Failed to generate page from ${pageFile.name}", e)
+                throw new GradleException("Failed to generate page from ${pageFile.name}: ${e.message}", e)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Clarify failure cause when generating pages by including original exception message in rethrown `GradleException`.

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a11fa1442c8330bc0368707e8273d3