### PR TITLE
Add tests and fixes for open/close tag helpers

### DIFF
--- a/plugin/src/main/resources/scaffold/basic/helpers/close.groovy
+++ b/plugin/src/main/resources/scaffold/basic/helpers/close.groovy
@@ -2,11 +2,9 @@ package scaffold.basic.helpers
 
 import com.github.jknack.handlebars.Helper
 import com.github.jknack.handlebars.Options
+import com.github.jknack.handlebars.Handlebars
 
 return { Object tagArg, Options options ->
     String tag = String.valueOf(tagArg ?: "").trim()
-    String cls = (opts.hash("class") ?: "").toString().trim()
-    String classAttr = cls ? " class=\"${handlebars.escapeExpression(cls)}\"" : ""
-
     new Handlebars.SafeString("</${tag}>")
 } as Helper

--- a/plugin/src/main/resources/scaffold/basic/helpers/open.groovy
+++ b/plugin/src/main/resources/scaffold/basic/helpers/open.groovy
@@ -2,11 +2,12 @@ package scaffold.basic.helpers
 
 import com.github.jknack.handlebars.Helper
 import com.github.jknack.handlebars.Options
+import com.github.jknack.handlebars.Handlebars
 
 return { Object tagArg, Options options ->
     String tag = String.valueOf(tagArg ?: "").trim()
-    String cls = (opts.hash("class") ?: "").toString().trim()
-    String classAttr = cls ? " class=\"${handlebars.escapeExpression(cls)}\"" : ""
+    String cls = (options.hash['class'] ?: "").toString().trim()
+    String classAttr = cls ? " class=\"${Handlebars.Utils.escapeExpression(cls)}\"" : ""
 
     new Handlebars.SafeString("<${tag}${classAttr}>")
 } as Helper

--- a/plugin/src/test/groovy/biz/digitalindustry/grimoire/helpers/OpenCloseHelperSpec.groovy
+++ b/plugin/src/test/groovy/biz/digitalindustry/grimoire/helpers/OpenCloseHelperSpec.groovy
@@ -1,0 +1,46 @@
+package biz.digitalindustry.grimoire.helpers
+
+import com.github.jknack.handlebars.Handlebars
+import groovy.lang.Binding
+import groovy.lang.GroovyShell
+import spock.lang.Specification
+
+class OpenCloseHelperSpec extends Specification {
+
+    private final Handlebars handlebars = new Handlebars()
+
+    private Object loadHelper(String name) {
+        def binding = new Binding([handlebars: handlebars])
+        def shell = new GroovyShell(binding)
+        def url = this.class.classLoader.getResource("scaffold/basic/helpers/${name}.groovy")
+        shell.evaluate(url.toURI())
+    }
+
+    def "open helper renders tag with optional class"() {
+        given:
+        handlebars.registerHelper("open", loadHelper("open"))
+
+        expect:
+        handlebars.compileInline(template).apply([:]) == expected
+
+        where:
+        template                           || expected
+        '{{open "div"}}'                   || '<div>'
+        '{{open "div" class="container"}}' || '<div class="container">'
+        '{{open "div" class="<evil>"}}'    || '<div class="&lt;evil&gt;">'
+    }
+
+    def "close helper renders closing tag"() {
+        given:
+        handlebars.registerHelper("close", loadHelper("close"))
+
+        expect:
+        handlebars.compileInline(template).apply([:]) == expected
+
+        where:
+        template         || expected
+        '{{close "div"}}' || '</div>'
+        '{{close "span"}}' || '</span>'
+    }
+}
+


### PR DESCRIPTION
## Summary
- fix open and close helper implementations
- add Spock specs to verify open and close helpers

## Testing
- `./gradlew :plugin:test`


------
https://chatgpt.com/codex/tasks/task_e_68a154dd97348330a328c55fe45513e5