### PR TITLE
Compile markdown templates before converting to HTML

### DIFF
--- a/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/SiteGenTask.groovy
+++ b/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/SiteGenTask.groovy
@@ -145,8 +145,13 @@ abstract class SiteGenTask extends DefaultTask {
                 def pageContext = parsed.metadata
                 def mergedContext = config + pageContext
 
-                def bodyContent = pageFile.name.endsWith(".md") ? MarkdownParser.toHtml(parsed.content) : parsed.content
-                def renderedContent = engine.compileInline(bodyContent).apply(mergedContext)
+                def renderedContent
+                if (pageFile.name.endsWith(".md")) {
+                    def templatedMarkdown = engine.compileInline(parsed.content).apply(mergedContext)
+                    renderedContent = MarkdownParser.toHtml(templatedMarkdown)
+                } else {
+                    renderedContent = engine.compileInline(parsed.content).apply(mergedContext)
+                }
 
                 def layoutName = pageContext.layout ?: "default"
                 def layoutFile = new File(layoutDir, "${layoutName}.hbs")


### PR DESCRIPTION
## Summary
- Apply Handlebars to markdown files before converting them to HTML
- Retain single-pass rendering for HTML pages

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a15bae32ac8330b40651459acc840f