### PR TITLE
test: cover helpers with quoted arguments in markdown

### DIFF
--- a/plugin/src/main/groovy/biz/digitalindustry/grimoire/parser/MarkdownParser.groovy
+++ b/plugin/src/main/groovy/biz/digitalindustry/grimoire/parser/MarkdownParser.groovy
@@ -10,6 +10,8 @@ class MarkdownParser {
 
     static String toHtml(String markdown) {
         def document = parser.parse(markdown)
-        return renderer.render(document)
+        def html = renderer.render(document)
+        // Unescape HTML entities that may appear inside Handlebars helpers
+        html.replace('&quot;', '"')
     }
 }

--- a/plugin/src/test/groovy/biz/digitalindustry/grimoire/SiteGenPluginSpec.groovy
+++ b/plugin/src/test/groovy/biz/digitalindustry/grimoire/SiteGenPluginSpec.groovy
@@ -70,6 +70,21 @@ class SiteGenPluginSpec extends Specification {
         assert outputFile.text.contains("Test-Bot")
     }
 
+    def "helper quoted arguments render without HTML entities"() {
+        when: "grim-gen processes markdown with helpers"
+        GradleRunner.create()
+                .withProjectDir(testDir.toFile())
+                .withArguments("grim-gen", "--stacktrace")
+                .withPluginClasspath()
+                .build()
+
+        then: "Rendered page contains helper output without &quot; entities"
+        def outputFile = new File(testDir.toFile(), "public/quoted-helper.html")
+        outputFile.exists()
+        outputFile.text.contains("<div>")
+        !outputFile.text.contains("&quot;")
+    }
+
     def "skips page generation when destination is directory"() {
         given: "An existing directory where a page would be generated"
         def conflictDir = new File(testDir.toFile(), "public/index.html")

--- a/plugin/src/test/resources/test-projects/basic-site/helpers/close.groovy
+++ b/plugin/src/test/resources/test-projects/basic-site/helpers/close.groovy
@@ -1,0 +1,8 @@
+import com.github.jknack.handlebars.Helper
+import com.github.jknack.handlebars.Options
+import com.github.jknack.handlebars.Handlebars
+
+return { Object tagArg, Options options ->
+    String tag = String.valueOf(tagArg ?: "").trim()
+    new Handlebars.SafeString("</${tag}>")
+} as Helper

--- a/plugin/src/test/resources/test-projects/basic-site/helpers/open.groovy
+++ b/plugin/src/test/resources/test-projects/basic-site/helpers/open.groovy
@@ -1,0 +1,11 @@
+import com.github.jknack.handlebars.Helper
+import com.github.jknack.handlebars.Options
+import com.github.jknack.handlebars.Handlebars
+
+return { Object tagArg, Options options ->
+    String tag = String.valueOf(tagArg ?: "").trim()
+    String cls = (options.hash['class'] ?: "").toString().trim()
+    String classAttr = cls ? " class=\"${Handlebars.Utils.escapeExpression(cls)}\"" : ""
+
+    new Handlebars.SafeString("<${tag}${classAttr}>")
+} as Helper

--- a/plugin/src/test/resources/test-projects/basic-site/pages/quoted-helper.md
+++ b/plugin/src/test/resources/test-projects/basic-site/pages/quoted-helper.md
@@ -1,0 +1,5 @@
+---
+title = "Quoted Helper"
+---
+
+{{open "div"}}Helper content{{close "div"}}


### PR DESCRIPTION
## Summary
- add markdown sample using helper with quoted argument
- ensure markdown parsing preserves quoted helper arguments
- test helper usage renders without &quot; entities

## Testing
- `./gradlew test --console=plain --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_68a15bb235808330aaeb8f0dd00f6e6e