### PR TITLE
feat: allow exclusions when copying resources

### DIFF
--- a/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/ScaffoldTask.groovy
+++ b/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/ScaffoldTask.groovy
@@ -81,7 +81,7 @@ abstract class ScaffoldTask extends DefaultTask {
                 // The path inside the JAR already points at the scaffold folder we want.
                 def sourceRoot = anchorPathInJar
 
-                ResourceCopier.copy(sourceRoot, destinationDir.get().asFile.toPath())
+                  ResourceCopier.copy(sourceRoot, destinationDir.get().asFile.toPath(), ['config.grim'])
 
                 if (writeConfig) {
                     copyAndModifyConfig(sourceRoot)
@@ -91,8 +91,8 @@ abstract class ScaffoldTask extends DefaultTask {
             }
         } else {
             // For a direct filesystem, it's simpler.
-            def sourceRoot = Paths.get(anchorUri)
-            ResourceCopier.copy(sourceRoot, destinationDir.get().getAsFile().toPath())
+              def sourceRoot = Paths.get(anchorUri)
+              ResourceCopier.copy(sourceRoot, destinationDir.get().getAsFile().toPath(), ['config.grim'])
             if (writeConfig) {
                 copyAndModifyConfig(sourceRoot)
             } else {

--- a/plugin/src/main/groovy/biz/digitalindustry/grimoire/util/ResourceCopier.groovy
+++ b/plugin/src/main/groovy/biz/digitalindustry/grimoire/util/ResourceCopier.groovy
@@ -17,11 +17,34 @@ class ResourceCopier {
      *
      * @param sourceRoot The root path of the resources to copy.
      * @param targetRoot The destination path where resources will be copied.
+     * @param skip Either a collection of path strings/Path objects relative to {@code sourceRoot}
+     *             or a predicate/closure that, given a relative {@link Path}, returns {@code true}
+     *             if that path (and its descendants) should be skipped.
      */
-    static void copy(Path sourceRoot, Path targetRoot) {
+    static void copy(Path sourceRoot, Path targetRoot, def skip = null) {
+        // Build a predicate for paths to skip
+        def shouldSkip
+        if (skip == null) {
+            shouldSkip = { Path p -> false }
+        } else if (skip instanceof Collection) {
+            def skipList = skip.collect { it.toString() }
+            shouldSkip = { Path p -> skipList.any { p.toString().startsWith(it) } }
+        } else if (skip instanceof java.util.function.Predicate) {
+            shouldSkip = { Path p -> (skip as java.util.function.Predicate<Path>).test(p) }
+        } else if (skip instanceof Closure) {
+            shouldSkip = { Path p -> (skip as Closure).call(p) }
+        } else {
+            shouldSkip = { Path p -> false }
+        }
+
         try {
             Files.walk(sourceRoot).forEach { sourcePath ->
-                def targetPath = targetRoot.resolve(sourceRoot.relativize(sourcePath).toString())
+                def relativePath = sourceRoot.relativize(sourcePath)
+                if (shouldSkip(relativePath)) {
+                    return
+                }
+
+                def targetPath = targetRoot.resolve(relativePath.toString())
 
                 if (Files.isDirectory(sourcePath)) {
                     // Always ensure the directory exists but never replace existing directories

--- a/plugin/src/test/groovy/biz/digitalindustry/grimoire/task/ScaffoldSpec.groovy
+++ b/plugin/src/test/groovy/biz/digitalindustry/grimoire/task/ScaffoldSpec.groovy
@@ -63,12 +63,13 @@ class ScaffoldSpec extends Specification {
         assert scaffoldRoot.isDirectory()
         assert new File(scaffoldRoot, "pages/index.html").exists()
         assert new File(scaffoldRoot, "layouts/default.hbs").exists()
-        assert new File(scaffoldRoot, "assets/style.css").exists()
+          assert new File(scaffoldRoot, "assets/style.css").exists()
+          assert !new File(scaffoldRoot, "config.grim").exists()
 
-        and: "The config file has the correct source directory"
-        def configFile = new File(testProjectDir, "config.grim")
-        assert configFile.exists()
-        assert configFile.text.contains("sourceDir = \"${targetDirName}\"")
+          and: "The config file has the correct source directory"
+          def configFile = new File(testProjectDir, "config.grim")
+          assert configFile.exists()
+          assert configFile.text.contains("sourceDir = \"${targetDirName}\"")
     }
 
     def "overwrites existing scaffold files but preserves directories"() {


### PR DESCRIPTION
## Summary
- extend ResourceCopier to support skipping paths via list or predicate
- skip config.grim when scaffolding a new site
- test that scaffolding omits config.grim from destination

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a29cd9fe7883309455772726caf2c7