### PR TITLE
Fix sidebar pages helper usage

### DIFF
--- a/plugin/src/main/resources/scaffold/basic/partials/sidebar.hbs
+++ b/plugin/src/main/resources/scaffold/basic/partials/sidebar.hbs
@@ -1,7 +1,7 @@
 {{!-- sidebar.hbs --}}
 <nav class="sidebar">
     <ul>
-        {{#each (Pages)}}
+        {{#each (pages)}}
             {{> sidebarItem this}}
         {{/each}}
     </ul>


### PR DESCRIPTION
## Summary
- use the registered `pages` helper in the sidebar partial

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ecff33f08330bd8a23d37e0703bd