### PR TITLE
refactor: use context.get for pagesDir

### DIFF
--- a/plugin/src/main/resources/scaffold/basic/helpers/pages.groovy
+++ b/plugin/src/main/resources/scaffold/basic/helpers/pages.groovy
@@ -2,7 +2,7 @@ import com.github.jknack.handlebars.Helper
 import com.github.jknack.handlebars.Options
 
 return { Object context, Options options ->
-    def pagesDir = options.context.model('pagesDir') as File
+    def pagesDir = options.context.get('pagesDir') as File
     if (!pagesDir?.exists() || !pagesDir.directory) {
         return []
     }


### PR DESCRIPTION
## Summary
- use `options.context.get` to resolve pages directory

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ef2a3498833094489a6f87714fd5