### PR TITLE
Recognize HTML and Markdown pages

### DIFF
--- a/plugin/src/main/resources/scaffold/basic/helpers/pages.groovy
+++ b/plugin/src/main/resources/scaffold/basic/helpers/pages.groovy
@@ -21,7 +21,7 @@ return { Object context, Options options ->
                             children: children
                     ]
                 }
-            } else if (file.name ==~ /(?i).*\.md|\.html?$/) {
+            } else if (file.name ==~ /(?i).*\.(md|html?)$/) {
                 def relativePath = root.toPath().relativize(file.toPath()).toString().replace(File.separator, "/")
                 def name = file.name.replaceFirst(/(?i)\.(md|html?)$/, "")
 

--- a/plugin/src/test/groovy/biz/digitalindustry/grimoire/helper/PagesHelperSpec.groovy
+++ b/plugin/src/test/groovy/biz/digitalindustry/grimoire/helper/PagesHelperSpec.groovy
@@ -1,0 +1,25 @@
+package biz.digitalindustry.grimoire.helper
+
+import com.github.jknack.handlebars.*
+import spock.lang.Specification
+
+class PagesHelperSpec extends Specification {
+    def "includes markdown and html files"() {
+        given:
+        def tmpDir = File.createTempDir()
+        new File(tmpDir, 'a.md').text = ''
+        new File(tmpDir, 'b.html').text = ''
+        new File(tmpDir, 'c.htm').text = ''
+
+        def helper = new GroovyShell().evaluate(new File('src/main/resources/scaffold/basic/helpers/pages.groovy'))
+
+        def context = Context.newBuilder([pagesDir: tmpDir]).build()
+        def options = new Options.Builder(new Handlebars(), '', TagType.VAR, context, Template.EMPTY).build()
+
+        when:
+        def items = helper.apply(null, options)
+
+        then:
+        items.collect { it.path }.toSet() == ['a.md', 'b.html', 'c.htm'] as Set
+    }
+}


### PR DESCRIPTION
## Summary
- support Markdown and HTML files when building sidebar items
- add unit test for sidebar helper

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a3f0a4967c8330a045f4f7f196b9f7