### PR TITLE
Include baseUrl in sidebar item links

### DIFF
--- a/plugin/src/main/resources/scaffold/basic/partials/sidebarItem.hbs
+++ b/plugin/src/main/resources/scaffold/basic/partials/sidebarItem.hbs
@@ -9,5 +9,5 @@
         </ul>
     </li>
 {{else if (eq type "file")}}
-    <li class="file"><a href="/{{path}}">{{name}}</a></li>
+    <li class="file"><a href="{{#if @root.baseUrl}}{{@root.baseUrl}}/{{path}}{{else}}/{{path}}{{/if}}">{{name}}</a></li>
 {{/if}}

--- a/plugin/src/test/groovy/biz/digitalindustry/grimoire/partial/SidebarItemPartialSpec.groovy
+++ b/plugin/src/test/groovy/biz/digitalindustry/grimoire/partial/SidebarItemPartialSpec.groovy
@@ -1,0 +1,22 @@
+package biz.digitalindustry.grimoire.partial
+
+import com.github.jknack.handlebars.Handlebars
+import spock.lang.Specification
+
+class SidebarItemPartialSpec extends Specification {
+    def "includes baseUrl in file links"() {
+        given:
+        def handlebars = new Handlebars()
+        def eqHelper = new GroovyShell().evaluate(new File('src/main/resources/scaffold/basic/helpers/eq.groovy'))
+        handlebars.registerHelper('eq', eqHelper)
+        def partial = new File('src/main/resources/scaffold/basic/partials/sidebarItem.hbs').text
+        def template = handlebars.compileInline(partial)
+        def context = [baseUrl: '/test', type: 'file', name: 'index', path: 'index.html']
+
+        when:
+        def output = template.apply(context)
+
+        then:
+        output.contains('<a href="/test/index.html">index</a>')
+    }
+}


### PR DESCRIPTION
## Summary
- prefix sidebar links with configured baseUrl to resolve correctly
- add unit test covering sidebar partial rendering with baseUrl

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a488ccb2a8833094f6198dec13430a