### PR TITLE
Strip page path extensions for sidebar links

### DIFF
--- a/plugin/src/main/resources/scaffold/basic/helpers/pages.groovy
+++ b/plugin/src/main/resources/scaffold/basic/helpers/pages.groovy
@@ -24,11 +24,12 @@ return { Object context, Options options ->
             } else if (file.name ==~ /(?i).*\.(md|html?)$/) {
                 def relativePath = root.toPath().relativize(file.toPath()).toString().replace(File.separator, "/")
                 def name = file.name.replaceFirst(/(?i)\.(md|html?)$/, "")
+                def path = relativePath.replaceFirst(/(?i)\.(md|html?)$/, "")
 
                 items << [
                         type: 'file',
                         name: name,
-                        path: relativePath
+                        path: path
                 ]
             }
         }

--- a/plugin/src/main/resources/scaffold/basic/partials/sidebarItem.hbs
+++ b/plugin/src/main/resources/scaffold/basic/partials/sidebarItem.hbs
@@ -9,5 +9,5 @@
         </ul>
     </li>
 {{else if (eq type "file")}}
-    <li class="file"><a href="{{#if @root.baseUrl}}{{@root.baseUrl}}/{{path}}{{else}}/{{path}}{{/if}}">{{name}}</a></li>
+    <li class="file"><a href="{{#if @root.baseUrl}}{{@root.baseUrl}}/{{path}}.html{{else}}/{{path}}.html{{/if}}">{{name}}</a></li>
 {{/if}}

--- a/plugin/src/test/groovy/biz/digitalindustry/grimoire/helper/PagesHelperSpec.groovy
+++ b/plugin/src/test/groovy/biz/digitalindustry/grimoire/helper/PagesHelperSpec.groovy
@@ -20,6 +20,6 @@ class PagesHelperSpec extends Specification {
         def items = helper.apply(null, options)
 
         then:
-        items.collect { it.path }.toSet() == ['a.md', 'b.html', 'c.htm'] as Set
+        items.collect { it.path }.toSet() == ['a', 'b', 'c'] as Set
     }
 }

--- a/plugin/src/test/groovy/biz/digitalindustry/grimoire/partial/SidebarItemPartialSpec.groovy
+++ b/plugin/src/test/groovy/biz/digitalindustry/grimoire/partial/SidebarItemPartialSpec.groovy
@@ -11,7 +11,7 @@ class SidebarItemPartialSpec extends Specification {
         handlebars.registerHelper('eq', eqHelper)
         def partial = new File('src/main/resources/scaffold/basic/partials/sidebarItem.hbs').text
         def template = handlebars.compileInline(partial)
-        def context = [baseUrl: '/test', type: 'file', name: 'index', path: 'index.html']
+        def context = [baseUrl: '/test', type: 'file', name: 'index', path: 'index']
 
         when:
         def output = template.apply(context)


### PR DESCRIPTION
## Summary
- drop `.md`, `.html`, `.htm` extensions when collecting page paths
- append `.html` to sidebar file links
- adjust helper/partial specs for new behavior

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a48e9051fc833087ca0707ae748943