### PR TITLE
fix: ensure sidebar links use .html extension

### DIFF
--- a/plugin/src/main/resources/scaffold/basic/helpers/htmlPath.groovy
+++ b/plugin/src/main/resources/scaffold/basic/helpers/htmlPath.groovy
@@ -1,0 +1,13 @@
+package scaffold.basic.helpers
+
+import com.github.jknack.handlebars.Helper
+import com.github.jknack.handlebars.Options
+
+return { Object path, Options options ->
+    def p = path?.toString() ?: ""
+    if (p.toLowerCase().endsWith('.html')) {
+        return p
+    }
+    p = p.replaceFirst(/\.[^\/]+$/, '')
+    return p + '.html'
+} as Helper

--- a/plugin/src/main/resources/scaffold/basic/partials/sidebarItem.hbs
+++ b/plugin/src/main/resources/scaffold/basic/partials/sidebarItem.hbs
@@ -9,5 +9,5 @@
         </ul>
     </li>
 {{else if (eq type "file")}}
-    <li class="file"><a href="{{#if @root.baseUrl}}{{@root.baseUrl}}/{{path}}.html{{else}}/{{path}}.html{{/if}}">{{name}}</a></li>
+    <li class="file"><a href="{{#if @root.baseUrl}}{{@root.baseUrl}}/{{htmlPath path}}{{else}}/{{htmlPath path}}{{/if}}">{{name}}</a></li>
 {{/if}}

--- a/plugin/src/test/groovy/biz/digitalindustry/grimoire/partial/SidebarItemPartialSpec.groovy
+++ b/plugin/src/test/groovy/biz/digitalindustry/grimoire/partial/SidebarItemPartialSpec.groovy
@@ -9,9 +9,47 @@ class SidebarItemPartialSpec extends Specification {
         def handlebars = new Handlebars()
         def eqHelper = new GroovyShell().evaluate(new File('src/main/resources/scaffold/basic/helpers/eq.groovy'))
         handlebars.registerHelper('eq', eqHelper)
+        def htmlPathHelper = new GroovyShell().evaluate(new File('src/main/resources/scaffold/basic/helpers/htmlPath.groovy'))
+        handlebars.registerHelper('htmlPath', htmlPathHelper)
         def partial = new File('src/main/resources/scaffold/basic/partials/sidebarItem.hbs').text
         def template = handlebars.compileInline(partial)
         def context = [baseUrl: '/test', type: 'file', name: 'index', path: 'index']
+
+        when:
+        def output = template.apply(context)
+
+        then:
+        output.contains('<a href="/test/index.html">index</a>')
+    }
+
+    def "strips non-html extensions"() {
+        given:
+        def handlebars = new Handlebars()
+        def eqHelper = new GroovyShell().evaluate(new File('src/main/resources/scaffold/basic/helpers/eq.groovy'))
+        handlebars.registerHelper('eq', eqHelper)
+        def htmlPathHelper = new GroovyShell().evaluate(new File('src/main/resources/scaffold/basic/helpers/htmlPath.groovy'))
+        handlebars.registerHelper('htmlPath', htmlPathHelper)
+        def partial = new File('src/main/resources/scaffold/basic/partials/sidebarItem.hbs').text
+        def template = handlebars.compileInline(partial)
+        def context = [baseUrl: '/test', type: 'file', name: 'README', path: 'README.md']
+
+        when:
+        def output = template.apply(context)
+
+        then:
+        output.contains('<a href="/test/README.html">README</a>')
+    }
+
+    def "keeps html extension"() {
+        given:
+        def handlebars = new Handlebars()
+        def eqHelper = new GroovyShell().evaluate(new File('src/main/resources/scaffold/basic/helpers/eq.groovy'))
+        handlebars.registerHelper('eq', eqHelper)
+        def htmlPathHelper = new GroovyShell().evaluate(new File('src/main/resources/scaffold/basic/helpers/htmlPath.groovy'))
+        handlebars.registerHelper('htmlPath', htmlPathHelper)
+        def partial = new File('src/main/resources/scaffold/basic/partials/sidebarItem.hbs').text
+        def template = handlebars.compileInline(partial)
+        def context = [baseUrl: '/test', type: 'file', name: 'index', path: 'index.html']
 
         when:
         def output = template.apply(context)


### PR DESCRIPTION
## Summary
- add htmlPath helper to normalize sidebar links
- use htmlPath helper in sidebarItem partial
- add tests for extension handling

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a495fb4a788330a98edf356cc9b69a