### PR TITLE
Remove config & output overrides from grim-serve task

### DIFF
--- a/plugin/src/main/groovy/biz/digitalindustry/grimoire/GrimoirePlugin.groovy
+++ b/plugin/src/main/groovy/biz/digitalindustry/grimoire/GrimoirePlugin.groovy
@@ -36,9 +36,6 @@ class GrimoirePlugin implements Plugin<Project> {
         project.tasks.register('grim-serve', ServeTask) { task ->
             task.group = TASK_GROUP
             task.description = 'Serves the static site.'
-
-            task.configFile.set(configFile)
-            task.outputDir.set(project.file(outputPath))
         }
 
         project.tasks.register('grim-init', ScaffoldTask) { task ->


### PR DESCRIPTION
## Summary
- Simplify `grim-serve` task registration by relying on `ServeTask` defaults

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b6917e7c83308bba46993bae86b8