### PR TITLE
Expose HttpServer via getter

### DIFF
--- a/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/ServeTask.groovy
+++ b/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/ServeTask.groovy
@@ -27,8 +27,10 @@ abstract class ServeTask extends DefaultTask {
     @InputDirectory
     abstract DirectoryProperty getWebRootDir()
 
-    @Internal
     private HttpServer server
+
+    @Internal
+    HttpServer getServer() { server }
 
     ServeTask() {
         getConfigFile().convention(getLayout().projectDirectory.file("config.grim"))


### PR DESCRIPTION
## Summary
- remove @Internal annotation from ServeTask.server field
- add @Internal getServer() to expose HttpServer instance

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c36e5f7c8330bc6c7e24af2b2897