### PR TITLE
feat: add groovy simple templates

### DIFF
--- a/plugin/src/main/groovy/biz/digitalindustry/grimoire/SimpleTemplateRenderer.groovy
+++ b/plugin/src/main/groovy/biz/digitalindustry/grimoire/SimpleTemplateRenderer.groovy
@@ -1,0 +1,43 @@
+package biz.digitalindustry.grimoire
+
+import groovy.text.SimpleTemplateEngine
+
+/**
+ * Renders Groovy simple templates with support for partials.
+ * Partials are loaded from a directory and can be referenced from templates
+ * using the `partial` closure, e.g. `${partial('name')}`.
+ */
+class SimpleTemplateRenderer {
+    private final SimpleTemplateEngine engine = new SimpleTemplateEngine()
+    private final Map<String, String> partials = [:]
+
+    SimpleTemplateRenderer(File partialsDir) {
+        if (partialsDir?.exists()) {
+            partialsDir.eachFileMatch(~/.*\.gtpl/) { File f ->
+                def name = f.name.replaceFirst(/\.gtpl$/, '')
+                partials[name] = f.text
+            }
+        }
+    }
+
+    String render(String template, Map<String, Object> context) {
+        if (!template.contains('$')) {
+            return template
+        }
+        def hasSyntax = (template =~ /\$\{[^}]+\}/) || (template =~ /(?m)\$[A-Za-z_][A-Za-z0-9_]*/)
+        if (!hasSyntax) {
+            return template
+        }
+        Closure partial = null
+        partial = { String name, Map<String, Object> model = [:] ->
+            def tpl = partials[name]
+            if (tpl == null) return ''
+            render(tpl, (context + model) + [partial: partial])
+        }
+        try {
+            return engine.createTemplate(template).make(context + [partial: partial]).toString()
+        } catch (IllegalArgumentException ignored) {
+            return template
+        }
+    }
+}

--- a/plugin/src/test/groovy/biz/digitalindustry/grimoire/GroovyTemplateSupportSpec.groovy
+++ b/plugin/src/test/groovy/biz/digitalindustry/grimoire/GroovyTemplateSupportSpec.groovy
@@ -1,0 +1,28 @@
+package biz.digitalindustry.grimoire
+
+import biz.digitalindustry.grimoire.task.SiteGenTask
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import java.nio.file.Files
+
+class GroovyTemplateSupportSpec extends Specification {
+    def "renders groovy templates and partials"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+        def task = project.tasks.create("site", SiteGenTask)
+        File siteDir = new File("src/test/resources/test-projects/groovy-site").absoluteFile
+        task.sourceDir.set(siteDir)
+        task.configFile.set(new File(siteDir, "config.grim"))
+        File outDir = Files.createTempDirectory("grim-out").toFile()
+        task.outputDir.set(outDir)
+
+        when:
+        task.generate()
+
+        then:
+        def output = new File(outDir, "index.html").text
+        output.contains("<h1>Test</h1>")
+        output.contains("<p>Hi Test</p>")
+        output.contains("<footer>2024</footer>")
+    }
+}

--- a/plugin/src/test/resources/test-projects/groovy-site/layouts/default.hbs
+++ b/plugin/src/test/resources/test-projects/groovy-site/layouts/default.hbs
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{title}}</title>
+</head>
+<body>
+    {{{content}}}
+    ${partial('footer')}
+</body>
+</html>

--- a/plugin/src/test/resources/test-projects/groovy-site/pages/index.html
+++ b/plugin/src/test/resources/test-projects/groovy-site/pages/index.html
@@ -1,0 +1,6 @@
+---
+title = "Test"
+copy = "2024"
+---
+<h1>{{title}}</h1>
+<p>Hi ${title}</p>

--- a/plugin/src/test/resources/test-projects/groovy-site/partials/footer.gtpl
+++ b/plugin/src/test/resources/test-projects/groovy-site/partials/footer.gtpl
@@ -1,0 +1,1 @@
+<footer>${copy}</footer>


### PR DESCRIPTION
## Summary
- support Groovy simple templates and partials via `SimpleTemplateRenderer`
- render both Handlebars and Groovy templates during site generation
- add integration test using `.gtpl` partials

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68b8a5059ef4833088e2579fe52a1330