### PR TITLE
docs: expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Grimoire is a lightweight and powerful static site generator built as a Gradle plugin. It's designed for developers who want to create fast, modern websites—like blogs, documentation, or portfolios—without leaving their existing build environment. By leveraging the power of Gradle and Groovy, Grimoire offers a deeply scriptable and customizable experience.
 
-At its core, Grimoire uses the popular Handlebars.java templating engine and supports content written in standard Markdown or HTML. It follows a simple convention-over-configuration approach, allowing you to get started quickly with a sensible project structure, while still providing the flexibility to configure paths and build processes to fit your needs.
+At its core, Grimoire uses the popular Handlebars.java templating engine, then runs the result through Groovy's `SimpleTemplateEngine`. This lets you mix `{{handlebars}}` helpers with `${groovy}` interpolation in the same file. Content can be written in standard Markdown or HTML, and the plugin follows a simple convention-over-configuration approach, allowing you to get started quickly with a sensible project structure while still providing the flexibility to configure paths and build processes to fit your needs.
 
 Whether you're building a personal blog or a project documentation site, Grimoire provides the tools to generate your static content efficiently, right from your Gradle build.
 
@@ -12,8 +12,8 @@ A typical Grimoire project follows this structure:
 ```
 <project-root>/ 
 |-- pages/             ← HTML or Markdown input content
-|-- layouts/           ← Handlebars layouts
-|-- partials/          ← Optional Handlebars partials
+|-- layouts/           ← Handlebars (.hbs) or Groovy (.gtpl) layouts
+|-- partials/          ← Optional Handlebars (.hbs) or Groovy (.gtpl) partials
 |-- data/              ← Optional page data (YAML/JSON/Groovy)
 |-- assets/            ← CSS/JS/images to copy as-is
 |-- public/            ← Final rendered output (or configurable)
@@ -21,7 +21,7 @@ A typical Grimoire project follows this structure:
 
 | Component     | Technology                                                   |
 | ------------- |--------------------------------------------------------------|
-| Templating    | [Handlebars.java](https://github.com/jknack/handlebars.java) |
+| Templating    | [Handlebars.java](https://github.com/jknack/handlebars.java) + Groovy `SimpleTemplateEngine` |
 | Gradle Plugin | Written in Groovy                                            |
 | Task          | `grim`                                                       |
 | Page Input    | HTML, Markdown                                               |
@@ -42,6 +42,34 @@ A typical Grimoire project follows this structure:
 | Usage              | Can be used in layouts, pages, or other partials      |
 | Registration       | Automatically load all `.hbs` files from partials dir |
 
+### Groovy Templates
+
+After Handlebars rendering, Grimoire evaluates the result with Groovy's `SimpleTemplateEngine`. This enables `${}` interpolation and Groovy-based partials alongside Handlebars syntax.
+
+#### Example
+
+```html
+<h1>{{title}}</h1>
+<p>Hello ${title}</p>
+```
+
+#### Groovy Layouts and Partials
+
+* Layouts may be written as `.gtpl` files. When both `default.hbs` and `default.gtpl` exist, `.hbs` is preferred.
+* Groovy partials live in the same `partials/` directory but use the `.gtpl` extension.
+* Include a Groovy partial with the special `partial` closure:
+
+```html
+${partial('footer', [copy: '2024'])}
+```
+
+and in `partials/footer.gtpl`:
+
+```html
+<footer>${copy}</footer>
+```
+
+The page/front‑matter context is merged with the optional map passed to `partial`, so values defined in `config.grim` or page metadata are available.
 
 
 ## Getting Started
@@ -72,8 +100,8 @@ This will generate a basic site structure alongside your existing files:
 <project-root>/
 ├── config.grim            # Groovy-based site configuration
 ├── pages/                 # Markdown or HTML page files
-├── layouts/               # Handlebars layouts
-├── partials/              # Optional Handlebars partials
+├── layouts/               # Handlebars (.hbs) or Groovy (.gtpl) layouts
+├── partials/              # Optional Handlebars or Groovy partials
 └── data/                  # Optional data in JSON/YAML/Groovy
 ```
 
@@ -112,4 +140,46 @@ To preview your site locally:
 The server will default to `http://localhost:8080` unless configured otherwise in `config.grim`.
 
 ### 5. Customize Your Site
+Grimoire reads configuration from a `config.grim` file located in the
+project root. The file is a Groovy script, allowing you to tailor the
+build process programmatically. Common options include tweaking
+directories and the port used by the preview server:
 
+```groovy
+// config.grim
+sourceDir = "docs"        // Where your content lives
+outputDir = "public"      // Build destination
+
+paths {
+    pages    = "pages"    // Content pages
+    layouts  = "layouts"  // Handlebars (.hbs) or Groovy (.gtpl) layouts
+    partials = "partials" // Reusable snippets (.hbs/.gtpl)
+    helpers  = "helpers"  // Groovy Handlebars helpers
+    assets   = "assets"   // Static files
+}
+
+server {
+    port = 9000           // Used by `grim-serve`
+}
+```
+
+Each block is optional—omit it to use the defaults. Helpers placed in
+the `helpers/` directory are automatically compiled and registered,
+while partials in `partials/` are available via the familiar
+`{{> partialName}}` syntax. Front matter in pages provides per-page
+metadata such as titles or layouts.
+
+---
+
+## Development
+
+This repository contains the Grimoire Gradle plugin. Run the full test
+suite with:
+
+```bash
+./gradlew check
+```
+
+## License
+
+Distributed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- explain how to customize paths and server settings via `config.grim`
- document helper/partial behavior and per-page metadata
- add development and license sections
- cover Groovy template support with `.gtpl` layouts, partials, and `${}` interpolation

## Testing
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68b8a8bb0050833093f23ec057c4f40e