### PR TITLE
fix: handle missing web root gracefully

### DIFF
--- a/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/ServeTask.groovy
+++ b/plugin/src/main/groovy/biz/digitalindustry/grimoire/task/ServeTask.groovy
@@ -7,7 +7,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
@@ -24,7 +23,7 @@ abstract class ServeTask extends DefaultTask {
     @InputFile
     abstract RegularFileProperty getConfigFile()
 
-    @InputDirectory
+    @Internal
     abstract DirectoryProperty getWebRootDir()
 
     private HttpServer server


### PR DESCRIPTION
## Summary
- avoid early validation of web root directory for `grim-serve`
- look up `outputDir` from `config.grim` at execution time

## Testing
- `./gradlew :plugin:build`
- `./gradlew grim-serve` *(fails: Web root directory to serve not found or not a directory: /workspace/grimoire/nonexistent. Please run 'grim-gen' first.)*

------
https://chatgpt.com/codex/tasks/task_e_68b9206928dc8330b8d9d4fef91017cc